### PR TITLE
Add support for Python 3.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Change log for gocept.pytestlayer
 
 - Make tests compatible with pytest >= 7.3.
 
-- Add support for Python 3.11.
+- Add support for Python 3.12.
 
 
 8.1 (2022-09-05)

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
 Programming Language :: Python :: Implementation
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy

--- a/src/gocept/pytestlayer/fixture.py
+++ b/src/gocept/pytestlayer/fixture.py
@@ -1,8 +1,8 @@
 import contextlib
-import imp
 import pytest
 import re
 import time
+import types
 import zope.dottedname.resolve
 
 
@@ -204,7 +204,7 @@ def parsefactories(collector, layer):
     ns = create(layer)
     if ns:
         name = get_fixture_name(layer, scope='function')
-        module = imp.new_module(name)
+        module = types.ModuleType(name)
         module.__dict__.update(ns)
         collector.session._fixturemanager.parsefactories(module, '')
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py39,
     py310,
     py311,
+    py312,
     pypy3,
     coverage,
 minversion = 2.4


### PR DESCRIPTION
The `imp` module has been removed in 3.12, replacing it with `types.ModuleType` was taken from pallets/flask@2de525c