### PR TITLE
Update supported pytest version to 8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Change log for zope.pytestlayer
 
 - Drop support for Python 3.7, 3.8.
 
+- Add support for pytest 8
 
 8.2 (2024-05-15)
 ================

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
 
     python_requires='>=3.9',
     install_requires=[
-        'pytest >= 6, < 8',
+        'pytest >= 8',
         'setuptools',
         'zope.dottedname',
     ],

--- a/src/zope/pytestlayer/layered.py
+++ b/src/zope/pytestlayer/layered.py
@@ -39,6 +39,8 @@ class LayeredTestCaseInstance(_pytest.unittest.UnitTestCase):
 
 class LayeredTestCaseFunction(_pytest.unittest.TestCaseFunction):
 
+    _instance = None
+
     @classmethod
     def from_parent(cls, parent, name, **kw):
         description = get_description(parent)
@@ -50,7 +52,7 @@ class LayeredTestCaseFunction(_pytest.unittest.TestCaseFunction):
         )
         function.layer = function.parent.layer
         function.tc_description = description
-        function._testcase = function.parent.obj
+        function._instance = function.parent.obj
         return function
 
     def setup(self):
@@ -65,10 +67,10 @@ class LayeredTestCaseFunction(_pytest.unittest.TestCaseFunction):
             self._request.getfixturevalue(fixture_name)
 
     def teardown(self):
-        _testcase = self._testcase
+        _instance = self._instance
         super().teardown()
         # Do not die with a meaningless error message when rerunning doctests:
-        self._testcase = _testcase
+        self._instance = _instance
 
     def reportinfo(self):
         return ('test_suite', None, self.tc_description)


### PR DESCRIPTION
pytest removed `_testcase_` in this [commit](https://github.com/pytest-dev/pytest/commit/1a5e0eb71d2af0ad113ccd9ee596c7d724d7a4b6) and added `_instance`.

Fixes #48 